### PR TITLE
Create function `submit_limit_jobs` that limit number of submitted job 

### DIFF
--- a/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/R/sideFunctions.R
+++ b/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/R/sideFunctions.R
@@ -4554,7 +4554,7 @@ waitTillCommandFinish = function(checkcommand = 'squeue --format="%A %.30j"',
 
 submit_limit_jobs = function(bch_file,
                              job_id_logfile,
-                             max_jobs=1500) {
+                             max_jobs=400) {
   message0("Start submit_limit_jobs")
   system(paste("echo > ", job_id_logfile))
   file <- file(bch_file, "r")

--- a/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/R/sideFunctions.R
+++ b/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/R/sideFunctions.R
@@ -4552,6 +4552,28 @@ waitTillCommandFinish = function(checkcommand = 'squeue --format="%A %.30j"',
   message0('continuing the pipeline ...')
 }
 
+submit_limit_jobs = function(bch_file, 
+                             job_id_logfile, 
+                             max_jobs=1500) {
+  message0("Start submit_limit_jobs")
+  system(paste("echo > ", job_id_logfile))
+  file <- file(bch_file, "r")
+  while (length(command <- readLines(file, n = 1, warn = FALSE)) > 0) {
+    while(TRUE) {
+      num_running <- as.integer(system("squeue | wc -l", wait=TRUE, intern = TRUE))
+      if(num_running <= max_jobs) {
+        message0("We are inside of break")
+        break
+      }
+      Sys.sleep(1)
+    }
+    job_id <- system(command, wait=TRUE, intern = TRUE)
+    system(paste("echo '", job_id, "' >> ", job_id_logfile))
+  }
+  close(file)
+  message0("End submit_limit_jobs")
+}
+
 filesContain = function(path = getwd(),
                         extension = NULL,
                         containWhat = 'Exit',

--- a/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/R/sideFunctions.R
+++ b/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/R/sideFunctions.R
@@ -4562,7 +4562,6 @@ submit_limit_jobs = function(bch_file,
     while(TRUE) {
       num_running <- as.integer(system("squeue | wc -l", wait=TRUE, intern = TRUE))
       if(num_running <= max_jobs) {
-        message0("We are inside of break")
         break
       }
       Sys.sleep(1)

--- a/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/R/sideFunctions.R
+++ b/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/R/sideFunctions.R
@@ -4552,8 +4552,8 @@ waitTillCommandFinish = function(checkcommand = 'squeue --format="%A %.30j"',
   message0('continuing the pipeline ...')
 }
 
-submit_limit_jobs = function(bch_file, 
-                             job_id_logfile, 
+submit_limit_jobs = function(bch_file,
+                             job_id_logfile,
                              max_jobs=1500) {
   message0("Start submit_limit_jobs")
   system(paste("echo > ", job_id_logfile))
@@ -4874,7 +4874,7 @@ StatsPipeline = function(path = getwd(),
                     DRversion)
 
   system('chmod 775 AllJobs.bch', wait = TRUE)
-  system('sbatch --job-name=impc_stats_pipeline_job --time=05:00:00 --mem=1G -o ../../compressed_logs/phase3_job_id.txt --wrap="bash ./AllJobs.bch"', wait = TRUE)
+  submit_limit_jobs(bch_file="AllJobs.bch", job_id_logfile="../../compressed_logs/phase3_job_id.txt")
   waitTillCommandFinish(
     WaitIfTheOutputContains = waitUntillSee,
     ignoreline = ignoreThisLineInWaitingCheck


### PR DESCRIPTION
Maximum number of jobs in SLURM queue is set to 400 as discussed with @rwilson-ebi

Closes #48
