### PR TITLE
Recreate conda environment from scratch

### DIFF
--- a/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/DESCRIPTION
+++ b/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/DESCRIPTION
@@ -9,4 +9,4 @@ Description: The required package for IMPC ageing pipeline.
 License: LGPL (>= 2)
 Encoding: UTF-8
 LazyData: true
-Imports: RJSONIO, methods, SmoothWin, stringi, base64enc, jsonlite, pingr, foreach, nlme, MASS, base, abind, OpenStats, rlist, DBI, RSQLite, gtools, plyr, robustbase, rlang, RPostgreSQL, data.table, arrow, Tmisc
+Imports: RJSONIO, methods, SmoothWin, stringi, base64enc, jsonlite, pingr, foreach, nlme, MASS, base, abind, OpenStats, rlist, DBI, RSQLite, gtools, plyr, robustbase, rlang, RPostgreSQL, data.table, arrow, Tmisc, rwebhdfs

--- a/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/DESCRIPTION
+++ b/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/DESCRIPTION
@@ -9,4 +9,4 @@ Description: The required package for IMPC ageing pipeline.
 License: LGPL (>= 2)
 Encoding: UTF-8
 LazyData: true
-Imports: RJSONIO, methods, SmoothWin, stringi, base64enc, jsonlite, pingr, foreach, nlme, MASS, base, abind, OpenStats, rlist, DBI, RSQLite, gtools, plyr, robustbase, rlang, RPostgreSQL, data.table, miniparquet, Tmisc
+Imports: RJSONIO, methods, SmoothWin, stringi, base64enc, jsonlite, pingr, foreach, nlme, MASS, base, abind, OpenStats, rlist, DBI, RSQLite, gtools, plyr, robustbase, rlang, RPostgreSQL, data.table, arrow, Tmisc

--- a/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/inst/extdata/StatsPipeline/0-ETL/Step2Parquet2Rdata.R
+++ b/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/inst/extdata/StatsPipeline/0-ETL/Step2Parquet2Rdata.R
@@ -3,11 +3,11 @@ args = commandArgs(trailingOnly = TRUE)
 ##################### STEP 1 #######################
 ####################################################
 f = function(files) {
-  requireNamespace("miniparquet")
+  requireNamespace("arrow")
   df = lapply(seq_along(files),
               function(i) {
                 message(i, '|', length(files), ' ~> ', files[i])
-                r = miniparquet::parquet_read(files[i])
+                r = as.data.frame(arrow::read_parquet(files[i]))
                 return(r)
               })
   ###############

--- a/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/inst/extdata/StatsPipeline/UpdatePackagesFromGithub.R
+++ b/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/inst/extdata/StatsPipeline/UpdatePackagesFromGithub.R
@@ -9,19 +9,6 @@ if (length(commandArgs(trailingOnly = TRUE)) != 2) {
 repository <- commandArgs(trailingOnly = TRUE)[1]
 branch <- commandArgs(trailingOnly = TRUE)[2]
 
-# Update DRrequiredAgeing
-install_github(
-  repo = paste(repository,
-               "/impc_stats_pipeline/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage",
-               sep = ""),
-  dependencies = TRUE,
-  upgrade = "always",
-  force = TRUE,
-  build = TRUE,
-  quiet = FALSE,
-  ref = branch
-)
-
 # Update SmoothWin
 install_github(
   repo = paste(repository,
@@ -43,4 +30,17 @@ install_github(
   force = TRUE,
   build = TRUE,
   quiet = FALSE
+)
+
+# Update DRrequiredAgeing
+install_github(
+  repo = paste(repository,
+               "/impc_stats_pipeline/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage",
+               sep = ""),
+  dependencies = TRUE,
+  upgrade = "always",
+  force = TRUE,
+  build = TRUE,
+  quiet = FALSE,
+  ref = branch
 )

--- a/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/inst/extdata/StatsPipeline/UpdatePackagesFromGithub.R
+++ b/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/inst/extdata/StatsPipeline/UpdatePackagesFromGithub.R
@@ -14,7 +14,7 @@ install_github(
   repo = paste(repository,
                "/impc_stats_pipeline/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage",
                sep = ""),
-  dependencies = FALSE,
+  dependencies = TRUE,
   upgrade = "always",
   force = TRUE,
   build = TRUE,
@@ -27,7 +27,7 @@ install_github(
   repo = paste(repository,
                "/impc_stats_pipeline/SoftWindowing/SmoothWin/SmoothWinPackage",
                sep = ""),
-  dependencies = FALSE,
+  dependencies = TRUE,
   upgrade = "always",
   force = TRUE,
   build = TRUE,
@@ -38,7 +38,7 @@ install_github(
 # Update OpenStats
 install_github(
   repo = "mpi2/OpenStats",
-  dependencies = FALSE,
+  dependencies = TRUE,
   upgrade = "always",
   force = TRUE,
   build = TRUE,

--- a/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/inst/extdata/StatsPipeline/UpdatePackagesFromGithub.R
+++ b/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/inst/extdata/StatsPipeline/UpdatePackagesFromGithub.R
@@ -8,7 +8,7 @@ if (length(commandArgs(trailingOnly = TRUE)) != 3) {
 # Retrieve the command line arguments.
 repository <- commandArgs(trailingOnly = TRUE)[1]
 branch <- commandArgs(trailingOnly = TRUE)[2]
-dependencies <- commandArgs(trailingOnly = TRUE)[3]
+dependencies <- as.logical(commandArgs(trailingOnly = TRUE)[3])
 
 # Update SmoothWin.
 install_github(

--- a/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/inst/extdata/StatsPipeline/UpdatePackagesFromGithub.R
+++ b/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/inst/extdata/StatsPipeline/UpdatePackagesFromGithub.R
@@ -1,20 +1,21 @@
 library(devtools)
 
-# Check if the correct number of arguments is provided
-if (length(commandArgs(trailingOnly = TRUE)) != 2) {
-  stop("Please provide exactly two arguments: repository name and branch name.")
+# Check if the correct number of arguments is provided.
+if (length(commandArgs(trailingOnly = TRUE)) != 3) {
+  stop("Please provide exactly three arguments: repository name, branch name, and whether to update dependencies.")
 }
 
-# Retrieve the command line arguments
+# Retrieve the command line arguments.
 repository <- commandArgs(trailingOnly = TRUE)[1]
 branch <- commandArgs(trailingOnly = TRUE)[2]
+dependencies <- commandArgs(trailingOnly = TRUE)[3]
 
-# Update SmoothWin
+# Update SmoothWin.
 install_github(
   repo = paste(repository,
                "/impc_stats_pipeline/SoftWindowing/SmoothWin/SmoothWinPackage",
                sep = ""),
-  dependencies = TRUE,
+  dependencies = dependencies,
   upgrade = "always",
   force = TRUE,
   build = TRUE,
@@ -22,22 +23,22 @@ install_github(
   ref = branch
 )
 
-# Update OpenStats
+# Update OpenStats.
 install_github(
   repo = "mpi2/OpenStats",
-  dependencies = TRUE,
+  dependencies = dependencies,
   upgrade = "always",
   force = TRUE,
   build = TRUE,
   quiet = FALSE
 )
 
-# Update DRrequiredAgeing
+# Update DRrequiredAgeing.
 install_github(
   repo = paste(repository,
                "/impc_stats_pipeline/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage",
                sep = ""),
-  dependencies = TRUE,
+  dependencies = dependencies,
   upgrade = "always",
   force = TRUE,
   build = TRUE,

--- a/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/inst/extdata/StatsPipeline/UpdatePackagesFromGithub.R
+++ b/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/inst/extdata/StatsPipeline/UpdatePackagesFromGithub.R
@@ -33,6 +33,16 @@ install_github(
   quiet = FALSE
 )
 
+# Update rwebhdfs.
+install_github(
+  repo = c("saurfang/rwebhdfs"),
+  dependencies = dependencies,
+  upgrade = "always",
+  force = TRUE,
+  build = TRUE,
+  quiet = FALSE
+)
+
 # Update DRrequiredAgeing.
 install_github(
   repo = paste(repository,

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -1,0 +1,30 @@
+# Recreating execution environment from scratch
+
+```bash
+# After becoming mi_stats
+
+# 1. Deactivate existing environment
+conda deactivate
+
+# 2. Update conda
+conda update -n base -c defaults conda
+
+# 3. Remove environment
+conda remove -n R2D2 --all
+
+# 4. Create new environment
+conda create --name R2D2
+
+# 5. Activate new environment
+conda activate R2D2
+
+# 6. Install R and packages
+conda install -c conda-forge r-base r-devtools libpq r-arrow r-mass r-rcppgsl r-magick r-matrix
+
+# 7. Run main package installation script
+export REMOTE="mpi2"
+export BRANCH="dev"
+wget -qO- https://raw.githubusercontent.com/${REMOTE}/impc_stats_pipeline/${BRANCH}/Late%20adults%20stats%20pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/inst/extdata/StatsPipeline/UpdatePackagesFromGithub.R > UpdatePackagesFromGithub.R
+Rscript UpdatePackagesFromGithub.R ${REMOTE} ${BRANCH} TRUE
+rm UpdatePackagesFromGithub.R
+```

--- a/run_pipeline.sh
+++ b/run_pipeline.sh
@@ -31,7 +31,7 @@ export MP_CHOOSER_FILE=$(echo -n '"'; realpath mp_chooser.json.Rdata | tr -d '\n
 echo "Update started"
 cd ${KOMP_PATH}/impc_statistical_pipeline/IMPC_DRs/stats_pipeline_input_dr${VERSION}
 wget https://raw.githubusercontent.com/${REMOTE}/impc_stats_pipeline/${BRANCH}/Late%20adults%20stats%20pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/inst/extdata/StatsPipeline/UpdatePackagesFromGithub.R
-Rscript UpdatePackagesFromGithub.R ${REMOTE} ${BRANCH}
+Rscript UpdatePackagesFromGithub.R ${REMOTE} ${BRANCH} FALSE
 rm UpdatePackagesFromGithub.R
 echo "Update completed"
 


### PR DESCRIPTION
Closes #37. 
Closes #41. 

- Migrated from `miniparquet` (no longer supported) to `arrow` R library.
- Add third argument called "dependencies" to `UpdatePackagesFromGithub.R`