### PR TITLE
Restructure the pipeline, optimise logs and performance

### DIFF
--- a/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/R/main.R
+++ b/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/R/main.R
@@ -300,7 +300,7 @@ mainAgeing = function(file = NULL                                    ,
                         cpu                  = cpu              ,
                         memory               = memory           ,
                         time                 = time             ,
-                        jobname              = "impc_job_" + DRversion,
+                        jobname              = paste0("impc_job_", DRversion),
                         extraBatchParameters =  extraBatchParameters
                       )
                       write(

--- a/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/R/main.R
+++ b/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/R/main.R
@@ -300,6 +300,7 @@ mainAgeing = function(file = NULL                                    ,
                         cpu                  = cpu              ,
                         memory               = memory           ,
                         time                 = time             ,
+                        jobname              = "impc_job_" + DRversion,
                         extraBatchParameters =  extraBatchParameters
                       )
                       write(

--- a/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/R/sideFunctions.R
+++ b/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/R/sideFunctions.R
@@ -702,7 +702,7 @@ BatchGenerator = function(file                       ,
   ro = paste(' -o ', paste0('"', oname, '.ClusterOut', '"'), sep = '')
   re = paste(' -e ', paste0('"', ename, '.ClusterErr', '"'), sep = '')
   rf = paste(
-    "sbatch --job-name= ", jobname, " --mem=", memory,
+    "sbatch --job-name=", jobname, " --mem=", memory,
     " --time=", time,
     extraBatchParameters  ,
     ' --cpus-per-task='                ,

--- a/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/R/sideFunctions.R
+++ b/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/R/sideFunctions.R
@@ -688,6 +688,7 @@ BatchGenerator = function(file                       ,
                           cpu = 1                    ,
                           memory = "8G"              ,
                           time = "10:00:00"          ,
+                          jobname = NULL             ,
                           extraBatchParameters = NULL) {
   dirOut = file.path(dir, 'ClusterOut')
   dirErr = file.path(dir, 'ClusterErr')
@@ -701,7 +702,7 @@ BatchGenerator = function(file                       ,
   ro = paste(' -o ', paste0('"', oname, '.ClusterOut', '"'), sep = '')
   re = paste(' -e ', paste0('"', ename, '.ClusterErr', '"'), sep = '')
   rf = paste(
-    "sbatch --job-name=impc_stats_pipeline_job --mem=", memory,
+    "sbatch --job-name= ", jobname, " --mem=", memory,
     " --time=", time,
     extraBatchParameters  ,
     ' --cpus-per-task='                ,

--- a/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/inst/extdata/StatsPipeline/jobs/InputDataGenerator.R
+++ b/Late adults stats pipeline/DRrequiredAgeing/DRrequiredAgeingPackage/inst/extdata/StatsPipeline/jobs/InputDataGenerator.R
@@ -20,7 +20,8 @@ generate_data <- function(args, thresh = 4) {
     controlSize = 1500,
     extraBatchParameters = NULL,
     combineEAandLA = FALSE,
-    solrBaseURL = NULL
+    solrBaseURL = NULL,
+    DRversion = args[3]
   )
   trash <- NULL
   gc()

--- a/annotation_pipeline/loader.py
+++ b/annotation_pipeline/loader.py
@@ -91,7 +91,7 @@ def main():
     if not output_dir.exists():
         output_dir.mkdir()
 
-    output_file = output_dir / (file_list_path.name + "_.statpackets")
+    output_file = output_dir / (file_list_path.name + ".statpackets")
 
     for i, file in enumerate(file_list):
         file_path = Path(file)

--- a/annotation_pipeline/loader.py
+++ b/annotation_pipeline/loader.py
@@ -86,8 +86,8 @@ def main():
         file_list = [line.strip() for line in f]
     total_files = len(file_list)
 
-    # Store StatPackets temporary.
-    output_dir = Path("annotation_pipeline_output")
+    # Store StatPackets.
+    output_dir = Path("../annotation_pipeline_output")
     if not output_dir.exists():
         output_dir.mkdir()
 

--- a/annotation_pipeline/loader.py
+++ b/annotation_pipeline/loader.py
@@ -87,7 +87,7 @@ def main():
     total_files = len(file_list)
 
     # Store StatPackets temporary.
-    output_dir = Path("tmp")
+    output_dir = Path("annotation_pipeline_output")
     if not output_dir.exists():
         output_dir.mkdir()
 

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -123,7 +123,7 @@ fetch_script 0-ETL/Step4MergingRdataFiles.R
 sbatch --job-name=impc_stats_pipeline_job --time=01:00:00 --mem=1G -o ../compressed_logs/step4_job_id.txt --wrap="bash jobs_step4_MergeRdatas.bch"
 waitTillCommandFinish
 rm Step4MergingRdataFiles.R
-sbatch --job-name=zip_step2 --time=15:00:00 --mem=1G -o ../compressed_logs/zip_step4.txt --wrap="zip -r -m -q ../compressed_logs/step4_logs.zip ../compressed_logs/step4_logs/"
+sbatch --job-name=zip_step4 --time=15:00:00 --mem=1G -o ../compressed_logs/zip_step4.txt --wrap="zip -r -m -q ../compressed_logs/step4_logs.zip ../compressed_logs/step4_logs/"
 
 message0 "Phase I. Compressing the log files and house cleaning..."
 zip -q -rm ../compressed_logs/phase1_jobs.zip *.bch

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -198,10 +198,9 @@ R --quiet -e \
   storepath='$(realpath RPackage_backup)' \
 )"
 
-message0 "Compress phase III log files"
-find . -type f -name '*.ClusterOut' -exec zip -q -m ../compressed_logs/phase3_logs.zip {} +
-message0 "Compress phase III error files"
-find . -type f -name '*.ClusterErr' -exec zip -q -m ../compressed_logs/phase3_errs.zip {} +
+message0 "Submit phase III log and err files compression"
+sbatch --job-name=compress_logs --time=1-00:00:00 --mem=1G -o ../compressed_logs/zip_phase3_logs.txt --wrap="find . -type d -name 'ClusterOut' -exec zip -q -r -m ../compressed_logs/phase3_logs.zip {} \;"
+sbatch --job-name=compress_logs --time=1-00:00:00 --mem=1G -o ../compressed_logs/zip_phase3_errs.txt --wrap="find . -type d -name 'ClusterErr' -exec zip -q -r -m ../compressed_logs/phase3_errs.zip {} \;"
 
 message0 "This is the last step. If you see no file in the list below, the SP is successfully completed."
 

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -133,7 +133,7 @@ rm -rf ProcedureScatterRdata
 message0 "Starting Phase II, packaging the big data into small packages ..."
 for file in $(find Rdata -type f -exec realpath {} \;); do
   file_basename=$(basename $file .Rdata)
-  echo "sbatch --job-name=${JOBNAME} --mem=45G --time=6-00 -e ../compressed_logs/phase2_logs/${file_basename}.err -o ../compressed_logs/phase2_logs/${file_basename}.log --wrap='Rscript InputDataGenerator.R ${file} ${file_basename}'" >> DataGenerationJobList.bch
+  echo "sbatch --job-name=${JOBNAME} --mem=45G --time=6-00 -e ../compressed_logs/phase2_logs/${file_basename}.err -o ../compressed_logs/phase2_logs/${file_basename}.log --wrap='Rscript InputDataGenerator.R ${file} ${file_basename} ${VERSION}'" >> DataGenerationJobList.bch
 done
 fetch_script jobs/InputDataGenerator.R
 sbatch --job-name=${JOBNAME} --time=01:00:00 --mem=1G -o ../compressed_logs/phase2_job_id.txt --wrap="bash DataGenerationJobList.bch"

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -161,23 +161,18 @@ cd ../stats_results
 
 message0 "Running the IMPC statistical pipeline by submitting jobs..."
 if [ "${WINDOWING_PIPELINE}" = true ]; then
-  message0 "Inside loop"
   fetch_script jobs/function_windowed.R
-  message0 "Downloaded"
   mv function_windowed.R function.R
-  message0 "Renamed"
 else
   fetch_script function.R
 fi
-
-message0 "Before replace"
 R --quiet -e \
 "DRrequiredAgeing:::ReplaceWordInFile( \
   '$(realpath function.R)', \
   'DRversionNotSpecified', \
   ${VERSION} \
 )"
-message0 "After replace"
+
 chmod 775 AllJobs.bch
 submit_limit_jobs AllJobs.bch ../compressed_logs/phase3_job_id.txt
 waitTillCommandFinish

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -219,11 +219,11 @@ mv minijobs.bch ../../compressed_logs
 
 find . -type f -name '*_output.log' -exec zip -q -m ../../compressed_logs/minijobs_logs.zip {} +
 find . -type f -name '*_error.err' -exec zip -q -m ../../compressed_logs/minijobs_logs.zip {} +
-message0 "Moving single indeces into a separate directory called AnnotationExtractorAndHadoopLoader..."
-mkdir AnnotationExtractorAndHadoopLoader
-chmod 775 AnnotationExtractorAndHadoopLoader
-mv *.Ind AnnotationExtractorAndHadoopLoader
-cd AnnotationExtractorAndHadoopLoader
+message0 "Moving single indeces into a separate directory called annotation_extractor..."
+mkdir annotation_extractor
+chmod 775 annotation_extractor
+mv *.Ind annotation_extractor
+cd annotation_extractor
 
 message0 "Concatenating single index files to create a global index for the results..."
 cat *.Ind | shuf >> AllResultsIndeces.txt

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -152,14 +152,14 @@ find ./*/*_RawData/*.bch -type f | xargs  cat >> ../stats_results/AllJobs.bch
 
 message0 "Phase III. Initialising the statistical analysis..."
 cd ../stats_results
-message0 "Updating the dynamic contents from the IMPReSS..."
-R --quiet -e \
-"DRrequiredAgeing:::updateImpress( \
- updateImpressFileInThePackage = TRUE, \
- updateOptionalParametersList = TRUE, \
- updateTheSkipList = TRUE, \
- saveRdata = FALSE \
-)"
+# message0 "Updating the dynamic contents from the IMPReSS..."
+# R --quiet -e \
+# "DRrequiredAgeing:::updateImpress( \
+#  updateImpressFileInThePackage = TRUE, \
+#  updateOptionalParametersList = TRUE, \
+#  updateTheSkipList = TRUE, \
+#  saveRdata = FALSE \
+# )"
 
 message0 "Running the IMPC statistical pipeline by submitting jobs..."
 if [ "${WINDOWING_PIPELINE}" = true ]; then

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -226,10 +226,10 @@ mv *.Ind AnnotationExtractorAndHadoopLoader
 cd AnnotationExtractorAndHadoopLoader
 
 message0 "Concatenating single index files to create a global index for the results..."
-cat *.Ind >> AllResultsIndeces.txt
+cat *.Ind | shuf >> AllResultsIndeces.txt
 message0 "Zipping the single indeces..."
 zip -q -rm allsingleindeces.zip *.Ind
-split -50 AllResultsIndeces.txt split_index_
+split -1000 AllResultsIndeces.txt split_index_
 
 message0 "Convert the mp_chooser JSON file to Rdata..."
 R --quiet -e "a = jsonlite::fromJSON('../../../../mp_chooser.json');save(a,file='../../../../mp_chooser.json.Rdata')"

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -76,7 +76,8 @@ function submit_limit_jobs() {
 # Preparation.
 mkdir --mode=775 ${KOMP_PATH}/impc_statistical_pipeline/IMPC_DRs/stats_pipeline_input_dr${VERSION}
 cd ${KOMP_PATH}/impc_statistical_pipeline/IMPC_DRs/stats_pipeline_input_dr${VERSION}
-cp ${PARQUET_FOLDER}/*.parquet ./
+mkdir input_parquet_files
+cp ${PARQUET_FOLDER}/*.parquet ./input_parquet_files
 cp ${MP_CHOOSER_FOLDER}/part*.txt ./mp_chooser.json
 
 message0 "Update packages to the latest version"

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -150,14 +150,14 @@ find ./*/*_RawData/*.bch -type f | xargs  cat >> ../stats_results/phase3_jobs.bc
 
 message0 "Phase III. Initialising the statistical analysis..."
 cd ../stats_results
-# message0 "Updating the dynamic contents from the IMPReSS..."
-# R --quiet -e \
-# "DRrequiredAgeing:::updateImpress( \
-#  updateImpressFileInThePackage = TRUE, \
-#  updateOptionalParametersList = TRUE, \
-#  updateTheSkipList = TRUE, \
-#  saveRdata = FALSE \
-# )"
+message0 "Updating the dynamic contents from the IMPReSS..."
+R --quiet -e \
+"DRrequiredAgeing:::updateImpress( \
+ updateImpressFileInThePackage = TRUE, \
+ updateOptionalParametersList = TRUE, \
+ updateTheSkipList = TRUE, \
+ saveRdata = FALSE \
+)"
 
 message0 "Running the IMPC statistical pipeline by submitting jobs..."
 if [ "${WINDOWING_PIPELINE}" = true ]; then

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -146,11 +146,11 @@ zip -q -rm phase2_logs.zip DataGeneratingLog/
 mv phase2_logs.zip ../compressed_logs/
 
 message0 "Appending all procedure based jobs into one single file..."
-mkdir jobs
-find ./*/*_RawData/*.bch -type f | xargs  cat >> jobs/AllJobs.bch
+mkdir ../jobs
+find ./*/*_RawData/*.bch -type f | xargs  cat >> ../jobs/AllJobs.bch
 
 message0 "Phase III. Initialising the statistical analysis..."
-cd jobs
+cd ../jobs
 message0 "Updating the dynamic contents from the IMPReSS..."
 R --quiet -e \
 "DRrequiredAgeing:::updateImpress( \
@@ -162,20 +162,20 @@ R --quiet -e \
 
 message0 "Running the IMPC statistical pipeline by submitting jobs..."
 if [ "${WINDOWING_PIPELINE}" = true ]; then
-  fetch_script jobs/function_windowed.R
+  fetch_script ../jobs/function_windowed.R
   mv function_windowed.R function.R
 else
-  fetch_script jobs/function.R
+  fetch_script ../jobs/function.R
 fi
 
 R --quiet -e \
 "DRrequiredAgeing:::ReplaceWordInFile( \
-  '$(realpath function.R)', \
+  '$(realpath ../jobs/function.R)', \
   'DRversionNotSpecified', \
   ${VERSION} \
 )"
 chmod 775 AllJobs.bch
-submit_limit_jobs AllJobs.bch ../../compressed_logs/phase3_job_id.txt
+submit_limit_jobs AllJobs.bch ../compressed_logs/phase3_job_id.txt
 waitTillCommandFinish
 
 message0 "Postprocessing the IMPC statistical analysis results..."
@@ -203,7 +203,7 @@ message0 "This is the last step. If you see no file in the list below, the SP is
 
 # Annotation pipeline.
 message0 "Starting the IMPC annotation pipeline..."
-cd jobs/Results_IMPC_SP_Windowed/
+cd ../jobs/Results_IMPC_SP_Windowed/
 message0 "Step 1: Clean ups and creating the global index for the results."
 message0 "Indexing the results..."
 for dir in $(find . -mindepth 2 -maxdepth 2 -type d); do
@@ -213,12 +213,12 @@ for dir in $(find . -mindepth 2 -maxdepth 2 -type d); do
 -e ${base_dir}_error.err -o ${base_dir}_output.log --wrap=\"find $dir -type f -name '*.tsv' -exec realpath {} \; > $output_file\"" >> minijobs.bch
 done
 chmod 775 minijobs.bch
-submit_limit_jobs minijobs.bch ../../../compressed_logs/minijobs_job_id.txt
+submit_limit_jobs minijobs.bch ../../compressed_logs/minijobs_job_id.txt
 waitTillCommandFinish
-mv minijobs.bch ../../../compressed_logs
+mv minijobs.bch ../../compressed_logs
 
-find . -type f -name '*_output.log' -exec zip -q -m ../../../compressed_logs/minijobs_logs.zip {} +
-find . -type f -name '*_error.err' -exec zip -q -m ../../../compressed_logs/minijobs_logs.zip {} +
+find . -type f -name '*_output.log' -exec zip -q -m ../../compressed_logs/minijobs_logs.zip {} +
+find . -type f -name '*_error.err' -exec zip -q -m ../../compressed_logs/minijobs_logs.zip {} +
 message0 "Moving single indeces into a separate directory called AnnotationExtractorAndHadoopLoader..."
 mkdir AnnotationExtractorAndHadoopLoader
 chmod 775 AnnotationExtractorAndHadoopLoader

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -112,7 +112,7 @@ rm Step2Parquet2Rdata.R
 sbatch --job-name=zip_step2 --time=15:00:00 --mem=1G -o ../compressed_logs/zip_step2.txt --wrap="zip -r -m -q ../compressed_logs/step2_logs.zip ../compressed_logs/step2_logs/"
 
 message0 "Step 3. Merging pseudo Rdata files into single file for each procedure - jobs creator"
-dirs=$(find "${sp_results}/ProcedureScatterRdata" -maxdepth 1 -type d)
+dirs=$(find "${sp_results}/ProcedureScatterRdata" -maxdepth 1 -mindepth 1 -type d)
 for dir in $dirs; do
   file_name=$(basename "${dir}")
   echo "sbatch --job-name=impc_stats_pipeline_job --mem=50G --time=01:30:00 -e ../compressed_logs/step4_logs/${file_name}_step4.err -o ../compressed_logs/step4_logs/${file_name}_step4.log --wrap='Rscript Step4MergingRdataFiles.R ${dir}'" >> jobs_step4_MergeRdatas.bch

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -109,6 +109,7 @@ fetch_script 0-ETL/Step2Parquet2Rdata.R
 sbatch --job-name=impc_stats_pipeline_job --time=01:00:00 --mem=1G -o ../compressed_logs/step2_job_id.txt --wrap="bash jobs_step2_Parquet2Rdata.bch"
 waitTillCommandFinish
 rm Step2Parquet2Rdata.R
+sbatch --job-name=zip_step2 --time=15:00:00 --mem=1G -o ../compressed_logs/zip_step2.txt --wrap="zip -r -m -q ../compressed_logs/step2_logs.zip ../compressed_logs/step2_logs/"
 
 message0 "Step 3. Merging pseudo Rdata files into single file for each procedure - jobs creator"
 dirs=$(find "${sp_results}/ProcedureScatterRdata" -maxdepth 1 -type d)

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -258,5 +258,5 @@ waitTillCommandFinish
 message0 "Running Slurm jobs to compress logs..."
 mv annotation_jobs.bch ../compressed_logs
 sbatch --job-name=compress_logs --time=15:00:00 --mem=1G -o ../compressed_logs/zip_annotations.txt --wrap="zip -r -m -q ../compressed_logs/annotation_logs/.zip ../compressed_logs/annotation_logs/"
-sbatch --job-name=compress_logs --time=15:00:00 --mem=1G -o ../compressed_logs/zip_indeces.txt --wrap="find ../ -type f -name 'split_index_*' -exec zip -q -m splits.zip {} +"
+sbatch --job-name=compress_logs --time=15:00:00 --mem=1G -o ../compressed_logs/zip_indeces.txt --wrap="find . -type f -name 'split_index_*' -exec zip -q -m splits.zip {} +"
 message0 "Job done."

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -229,7 +229,7 @@ message0 "Moving single indeces into a separate directory called annotation_extr
 mkdir ../../annotation_extractor
 chmod 775 ../../annotation_extractor
 cd ../../annotation_extractor
-mv stats_results/Results_IMPC_SP_Windowed/*.Ind .
+mv ../stats_results/Results_IMPC_SP_Windowed/*.Ind .
 
 message0 "Concatenating single index files to create a global index for the results..."
 cat *.Ind | shuf >> AllResultsIndeces.txt

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -217,7 +217,7 @@ waitTillCommandFinish
 mv minijobs.bch ../../compressed_logs
 sbatch --job-name=compress_logs --time=15:00:00 --mem=1G -o ../../compressed_logs/zip_minijobs.txt --wrap="zip -r -m -q ../../compressed_logs/minijobs_logs.zip ../../compressed_logs/minijobs_logs/"
 
-message0 "Moving single indeces into a separate directory called annotation_extractor..."
+message0 "Moving single indices into a separate directory called annotation_extractor..."
 mkdir ../../annotation_extractor
 chmod 775 ../../annotation_extractor
 cd ../../annotation_extractor
@@ -225,8 +225,8 @@ mv ../stats_results/Results_IMPC_SP_Windowed/*.Ind .
 
 message0 "Concatenating single index files to create a global index for the results..."
 cat *.Ind | shuf --random-source=<(yes "42") >> global_results_index.txt
-message0 "Zipping the single indeces..."
-sbatch --job-name=compress_logs --time=15:00:00 --mem=1G -o ../compressed_logs/zip_indeces.txt --wrap="zip -r -m -q allsingleindeces.zip *.Ind"
+message0 "Zipping the single indices..."
+sbatch --job-name=compress_logs --time=15:00:00 --mem=1G -o ../compressed_logs/zip_indices.txt --wrap="zip -r -m -q individual_indices.zip *.Ind"
 split -1000 global_results_index.txt split_index_
 
 message0 "Convert the mp_chooser JSON file to Rdata..."
@@ -258,5 +258,5 @@ waitTillCommandFinish
 message0 "Running Slurm jobs to compress logs..."
 mv annotation_jobs.bch ../compressed_logs
 sbatch --job-name=compress_logs --time=15:00:00 --mem=1G -o ../compressed_logs/zip_annotations.txt --wrap="zip -r -m -q ../compressed_logs/annotation_logs.zip ../compressed_logs/annotation_logs/"
-sbatch --job-name=compress_logs --time=15:00:00 --mem=1G -o ../compressed_logs/zip_indeces.txt --wrap="find . -type f -name 'split_index_*' -exec zip -q -m splits.zip {} +"
+sbatch --job-name=compress_logs --time=15:00:00 --mem=1G -o ../compressed_logs/zip_splits.txt --wrap="find . -type f -name 'split_index_*' -exec zip -q -m splits.zip {} +"
 message0 "Job done."

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -224,10 +224,10 @@ cd ../../annotation_extractor
 mv ../stats_results/Results_IMPC_SP_Windowed/*.Ind .
 
 message0 "Concatenating single index files to create a global index for the results..."
-cat *.Ind | shuf >> AllResultsIndeces.txt
+cat *.Ind | shuf --random-source=<(yes "42") >> global_results_index.txt
 message0 "Zipping the single indeces..."
 sbatch --job-name=compress_logs --time=15:00:00 --mem=1G -o ../compressed_logs/zip_indeces.txt --wrap="zip -r -m -q allsingleindeces.zip *.Ind"
-split -1000 AllResultsIndeces.txt split_index_
+split -1000 global_results_index.txt split_index_
 
 message0 "Convert the mp_chooser JSON file to Rdata..."
 R --quiet -e "a = jsonlite::fromJSON('../mp_chooser.json');save(a,file='../mp_chooser.json.Rdata')"

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -215,7 +215,7 @@ chmod 775 minijobs.bch
 submit_limit_jobs minijobs.bch ../../compressed_logs/minijobs_job_id.txt
 waitTillCommandFinish
 mv minijobs.bch ../../compressed_logs
-sbatch --job-name=compress_logs --time=15:00:00 --mem=1G -o ../compressed_logs/zip_minijobs.txt --wrap="zip -r -m -q ../../compressed_logs/minijobs_logs.zip ../../compressed_logs/minijobs_logs/"
+sbatch --job-name=compress_logs --time=15:00:00 --mem=1G -o ../../compressed_logs/zip_minijobs.txt --wrap="zip -r -m -q ../../compressed_logs/minijobs_logs.zip ../../compressed_logs/minijobs_logs/"
 
 message0 "Moving single indeces into a separate directory called annotation_extractor..."
 mkdir ../../annotation_extractor

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -109,7 +109,7 @@ fetch_script 0-ETL/Step2Parquet2Rdata.R
 sbatch --job-name=impc_stats_pipeline_job --time=01:00:00 --mem=1G -o ../compressed_logs/step2_job_id.txt --wrap="bash jobs_step2_Parquet2Rdata.bch"
 waitTillCommandFinish
 rm Step2Parquet2Rdata.R
-sbatch --job-name=zip_step2 --time=15:00:00 --mem=1G -o ../compressed_logs/zip_step2.txt --wrap="zip -r -m -q ../compressed_logs/step2_logs.zip ../compressed_logs/step2_logs/"
+sbatch --job-name=compress_logs --time=15:00:00 --mem=1G -o ../compressed_logs/zip_step2.txt --wrap="zip -r -m -q ../compressed_logs/step2_logs.zip ../compressed_logs/step2_logs/"
 
 message0 "Step 3. Merging pseudo Rdata files into single file for each procedure - jobs creator"
 dirs=$(find "${sp_results}/ProcedureScatterRdata" -maxdepth 1 -mindepth 1 -type d)
@@ -123,7 +123,7 @@ fetch_script 0-ETL/Step4MergingRdataFiles.R
 sbatch --job-name=impc_stats_pipeline_job --time=01:00:00 --mem=1G -o ../compressed_logs/step4_job_id.txt --wrap="bash jobs_step4_MergeRdatas.bch"
 waitTillCommandFinish
 rm Step4MergingRdataFiles.R
-sbatch --job-name=zip_step4 --time=15:00:00 --mem=1G -o ../compressed_logs/zip_step4.txt --wrap="zip -r -m -q ../compressed_logs/step4_logs.zip ../compressed_logs/step4_logs/"
+sbatch --job-name=compress_logs --time=15:00:00 --mem=1G -o ../compressed_logs/zip_step4.txt --wrap="zip -r -m -q ../compressed_logs/step4_logs.zip ../compressed_logs/step4_logs/"
 
 message0 "Phase I. Compressing the log files and house cleaning..."
 zip -q -rm ../compressed_logs/phase1_jobs.zip *.bch
@@ -142,7 +142,7 @@ rm InputDataGenerator.R
 message0 "End of packaging data."
 message0 "Phase II. Compressing the log files and house cleaning..."
 mv *.bch  ../compressed_logs/phase2_logs/
-sbatch --job-name=zip_phase2 --time=15:00:00 --mem=1G -o ../compressed_logs/zip_phase2.txt --wrap="zip -r -m -q ../compressed_logs/phase2_logs.zip ../compressed_logs/phase2_logs/"
+sbatch --job-name=compress_logs --time=15:00:00 --mem=1G -o ../compressed_logs/zip_phase2.txt --wrap="zip -r -m -q ../compressed_logs/phase2_logs.zip ../compressed_logs/phase2_logs/"
 
 message0 "Appending all procedure based jobs into one single file..."
 mkdir ../stats_results

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -220,10 +220,10 @@ mv minijobs.bch ../../compressed_logs
 find . -type f -name '*_output.log' -exec zip -q -m ../../compressed_logs/minijobs_logs.zip {} +
 find . -type f -name '*_error.err' -exec zip -q -m ../../compressed_logs/minijobs_logs.zip {} +
 message0 "Moving single indeces into a separate directory called annotation_extractor..."
-mkdir annotation_extractor
-chmod 775 annotation_extractor
-mv *.Ind annotation_extractor
-cd annotation_extractor
+mkdir ../annotation_extractor
+chmod 775 ../annotation_extractor
+mv *.Ind ../annotation_extractor
+cd ../annotation_extractor
 
 message0 "Concatenating single index files to create a global index for the results..."
 cat *.Ind | shuf >> AllResultsIndeces.txt
@@ -232,8 +232,8 @@ zip -q -rm allsingleindeces.zip *.Ind
 split -1000 AllResultsIndeces.txt split_index_
 
 message0 "Convert the mp_chooser JSON file to Rdata..."
-R --quiet -e "a = jsonlite::fromJSON('../../../../mp_chooser.json');save(a,file='../../../../mp_chooser.json.Rdata')"
-export MP_CHOOSER_FILE=$(realpath ../../../../mp_chooser.json.Rdata | tr -d '\n')
+R --quiet -e "a = jsonlite::fromJSON('../mp_chooser.json');save(a,file='../mp_chooser.json.Rdata')"
+export MP_CHOOSER_FILE=$(realpath ../mp_chooser.json.Rdata | tr -d '\n')
 
 if [[ -z "${MP_CHOOSER_FILE}" || ! -f "${MP_CHOOSER_FILE}" ]]; then
     echo -e "ERROR: mp_chooser not found at location\n\t${MP_CHOOSER_FILE}"
@@ -255,11 +255,11 @@ python3.10 -m pip install pandas
 
 message0 "Downloading the action script..."
 fetch_script loader.py annotation_pipeline
-submit_limit_jobs annotation_jobs.bch ../../../../compressed_logs/annotation_job_id.txt
+submit_limit_jobs annotation_jobs.bch ../compressed_logs/annotation_job_id.txt
 waitTillCommandFinish
 
 message0 "Zipping logs..."
-mv annotation_jobs.bch ../../../../compressed_logs
-zip -q -rm ../../../../compressed_logs/annotation_logs.zip log/* err/* out/*
+mv annotation_jobs.bch ../compressed_logs
+zip -q -rm ../compressed_logs/annotation_logs.zip log/* err/* out/*
 zip -q -rm splits.zip split_index_*
 message0 "Job done."

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -257,6 +257,6 @@ waitTillCommandFinish
 
 message0 "Running Slurm jobs to compress logs..."
 mv annotation_jobs.bch ../compressed_logs
-sbatch --job-name=compress_logs --time=15:00:00 --mem=1G -o ../compressed_logs/zip_annotations.txt --wrap="zip -r -m -q ../compressed_logs/annotation_logs/.zip ../compressed_logs/annotation_logs/"
+sbatch --job-name=compress_logs --time=15:00:00 --mem=1G -o ../compressed_logs/zip_annotations.txt --wrap="zip -r -m -q ../compressed_logs/annotation_logs.zip ../compressed_logs/annotation_logs/"
 sbatch --job-name=compress_logs --time=15:00:00 --mem=1G -o ../compressed_logs/zip_indeces.txt --wrap="find . -type f -name 'split_index_*' -exec zip -q -m splits.zip {} +"
 message0 "Job done."

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -164,7 +164,7 @@ cd ../stats_results
 message0 "Running the IMPC statistical pipeline by submitting jobs..."
 if [ "${WINDOWING_PIPELINE}" = true ]; then
   message0 "Inside loop"
-  fetch_script function_windowed.R
+  fetch_script jobs/function_windowed.R
   message0 "Downloaded"
   mv function_windowed.R function.R
   message0 "Renamed"

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -88,12 +88,12 @@ message0 "Update completed"
 
 # Statistical pipeline.
 message0 "Starting the IMPC statistical pipeline..."
-mkdir SP compressed_logs
+mkdir stats_batching compressed_logs
 export input_path=$(realpath .)
-export sp_results=$(realpath SP)
+export sp_results=$(realpath stats_batching)
 message0 "Parquet files path: ${input_path}"
 message0 "Output path: ${sp_results}"
-cd SP
+cd stats_batching
 
 message0 "Phase I. Convert parquet files into Rdata..."
 
@@ -147,11 +147,11 @@ zip -q -rm phase2_logs.zip DataGeneratingLog/
 mv phase2_logs.zip ../compressed_logs/
 
 message0 "Appending all procedure based jobs into one single file..."
-mkdir ../jobs
-find ./*/*_RawData/*.bch -type f | xargs  cat >> ../jobs/AllJobs.bch
+mkdir ../stats_results
+find ./*/*_RawData/*.bch -type f | xargs  cat >> ../stats_results/AllJobs.bch
 
 message0 "Phase III. Initialising the statistical analysis..."
-cd ../jobs
+cd ../stats_results
 message0 "Updating the dynamic contents from the IMPReSS..."
 R --quiet -e \
 "DRrequiredAgeing:::updateImpress( \
@@ -163,15 +163,15 @@ R --quiet -e \
 
 message0 "Running the IMPC statistical pipeline by submitting jobs..."
 if [ "${WINDOWING_PIPELINE}" = true ]; then
-  fetch_script ../jobs/function_windowed.R
-  mv function_windowed.R function.R
+  fetch_script ../stats_results/function_windowed.R
+  mv ../stats_results/function_windowed.R ../stats_results/function.R
 else
-  fetch_script ../jobs/function.R
+  fetch_script ../stats_results/function.R
 fi
 
 R --quiet -e \
 "DRrequiredAgeing:::ReplaceWordInFile( \
-  '$(realpath ../jobs/function.R)', \
+  '$(realpath ../stats_results/function.R)', \
   'DRversionNotSpecified', \
   ${VERSION} \
 )"
@@ -204,7 +204,7 @@ message0 "This is the last step. If you see no file in the list below, the SP is
 
 # Annotation pipeline.
 message0 "Starting the IMPC annotation pipeline..."
-cd ../jobs/Results_IMPC_SP_Windowed/
+cd ../stats_results/Results_IMPC_SP_Windowed/
 message0 "Step 1: Clean ups and creating the global index for the results."
 message0 "Indexing the results..."
 for dir in $(find . -mindepth 2 -maxdepth 2 -type d); do

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -163,10 +163,10 @@ cd ../stats_results
 
 message0 "Running the IMPC statistical pipeline by submitting jobs..."
 if [ "${WINDOWING_PIPELINE}" = true ]; then
-  fetch_script ../stats_results/function_windowed.R
-  mv ../stats_results/function_windowed.R ../stats_results/function.R
+  fetch_script function_windowed.R
+  mv function_windowed.R function.R
 else
-  fetch_script ../stats_results/function.R
+  fetch_script function.R
 fi
 
 R --quiet -e \

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -152,13 +152,13 @@ find ./*/*_RawData/*.bch -type f | xargs  cat >> ../02_sp_output/phase3_jobs.bch
 message0 "Phase III. Initialising the statistical analysis..."
 cd ../02_sp_output
 message0 "Updating the dynamic contents from the IMPReSS..."
-R --quiet -e \
-"DRrequiredAgeing:::updateImpress( \
- updateImpressFileInThePackage = TRUE, \
- updateOptionalParametersList = TRUE, \
- updateTheSkipList = TRUE, \
- saveRdata = FALSE \
-)"
+# R --quiet -e \
+# "DRrequiredAgeing:::updateImpress( \
+#  updateImpressFileInThePackage = TRUE, \
+#  updateOptionalParametersList = TRUE, \
+#  updateTheSkipList = TRUE, \
+#  saveRdata = FALSE \
+# )"
 
 message0 "Running the IMPC statistical pipeline by submitting jobs..."
 if [ "${WINDOWING_PIPELINE}" = true ]; then

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -163,18 +163,23 @@ cd ../stats_results
 
 message0 "Running the IMPC statistical pipeline by submitting jobs..."
 if [ "${WINDOWING_PIPELINE}" = true ]; then
+  message0 "Inside loop"
   fetch_script function_windowed.R
+  message0 "Downloaded"
   mv function_windowed.R function.R
+  message0 "Renamed"
 else
   fetch_script function.R
 fi
 
+message0 "Before replace"
 R --quiet -e \
 "DRrequiredAgeing:::ReplaceWordInFile( \
-  '$(realpath ../stats_results/function.R)', \
+  '$(realpath function.R)', \
   'DRversionNotSpecified', \
   ${VERSION} \
 )"
+message0 "After replace"
 chmod 775 AllJobs.bch
 submit_limit_jobs AllJobs.bch ../compressed_logs/phase3_job_id.txt
 waitTillCommandFinish

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -238,7 +238,7 @@ zip -q -rm allsingleindeces.zip *.Ind
 split -1000 AllResultsIndeces.txt split_index_
 
 message0 "Convert the mp_chooser JSON file to Rdata..."
-R --quiet -e "a = jsonlite::fromJSON('../mp_chooser.json');save(a,file='../mp_chooser.json.Rdata')"
+R --quiet -e "a = jsonlite::fromJSON('../../mp_chooser.json');save(a,file='../mp_chooser.json.Rdata')"
 export MP_CHOOSER_FILE=$(realpath ../mp_chooser.json.Rdata | tr -d '\n')
 
 if [[ -z "${MP_CHOOSER_FILE}" || ! -f "${MP_CHOOSER_FILE}" ]]; then

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -226,10 +226,10 @@ mv minijobs.bch ../../compressed_logs
 find . -type f -name '*_output.log' -exec zip -q -m ../../compressed_logs/minijobs_logs.zip {} +
 find . -type f -name '*_error.err' -exec zip -q -m ../../compressed_logs/minijobs_logs.zip {} +
 message0 "Moving single indeces into a separate directory called annotation_extractor..."
-mkdir ../annotation_extractor
-chmod 775 ../annotation_extractor
-mv *.Ind ../annotation_extractor
-cd ../annotation_extractor
+mkdir ../../annotation_extractor
+chmod 775 ../../annotation_extractor
+cd ../../annotation_extractor
+mv stats_results/Results_IMPC_SP_Windowed/*.Ind .
 
 message0 "Concatenating single index files to create a global index for the results..."
 cat *.Ind | shuf >> AllResultsIndeces.txt

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -100,7 +100,8 @@ message0 "Phase I. Convert parquet files into Rdata..."
 message0 "Step 1. Create jobs"
 step1_files=$(find ../input_parquet_files -type f -name '*.parquet' -exec realpath {} \;)
 for file in $step1_files; do
-  echo "sbatch --job-name=impc_stats_pipeline_job --mem=10G --time=00:10:00 -e ${file}.err -o ${file}.log --wrap='Rscript Step2Parquet2Rdata.R $file'" >> jobs_step2_Parquet2Rdata.bch
+  file_name=$(basename "${file}" .parquet)
+  echo "sbatch --job-name=impc_stats_pipeline_job --mem=10G --time=00:10:00 -e ../compressed_logs/step2_logs/${file_name}.err -o ../compressed_logs/step2_logs${file_name}.log --wrap='Rscript Step2Parquet2Rdata.R $file'" >> jobs_step2_Parquet2Rdata.bch
 done
 
 message0 "Step 2. Read parquet files and create pseudo Rdata"
@@ -108,8 +109,6 @@ fetch_script 0-ETL/Step2Parquet2Rdata.R
 sbatch --job-name=impc_stats_pipeline_job --time=01:00:00 --mem=1G -o ../compressed_logs/step2_job_id.txt --wrap="bash jobs_step2_Parquet2Rdata.bch"
 waitTillCommandFinish
 rm Step2Parquet2Rdata.R
-find ../input_parquet_files -type f -name '*.log' -exec zip -q -m ../compressed_logs/step2_logs.zip {} +
-find ../input_parquet_files -type f -name '*.err' -exec zip -q -m ../compressed_logs/step2_logs.zip {} +
 
 message0 "Step 3. Merging pseudo Rdata files into single file for each procedure - jobs creator"
 dirs=$(find "${sp_results}/ProcedureScatterRdata" -maxdepth 1 -type d)

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -146,7 +146,7 @@ sbatch --job-name=compress_logs --time=15:00:00 --mem=1G -o ../compressed_logs/z
 
 message0 "Appending all procedure based jobs into one single file..."
 mkdir ../stats_results
-find ./*/*_RawData/*.bch -type f | xargs  cat >> ../stats_results/AllJobs.bch
+find ./*/*_RawData/*.bch -type f | xargs  cat >> ../stats_results/phase3_jobs.bch
 
 message0 "Phase III. Initialising the statistical analysis..."
 cd ../stats_results
@@ -173,8 +173,8 @@ R --quiet -e \
   ${VERSION} \
 )"
 
-chmod 775 AllJobs.bch
-submit_limit_jobs AllJobs.bch ../compressed_logs/phase3_job_id.txt
+chmod 775 phase3_jobs.bch
+submit_limit_jobs phase3_jobs.bch ../compressed_logs/phase3_job_id.txt
 waitTillCommandFinish
 
 message0 "Postprocessing the IMPC statistical analysis results..."

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -238,6 +238,7 @@ if [[ -z "${MP_CHOOSER_FILE}" || ! -f "${MP_CHOOSER_FILE}" ]]; then
     exit 1
 fi
 
+message0 "Generate annotation jobs..."
 for file in $(find . -maxdepth 1 -type f -name "split_index*"); do
   echo "sbatch --job-name=impc_stats_pipeline_job --mem=5G --time=2-00 \
 -e ../compressed_logs/annotation_logs/$(basename "$file").err -o ../compressed_logs/annotation_logs/$(basename "$file").out --wrap='python3 loader.py $(basename "$file") ${MP_CHOOSER_FILE}'" >> annotation_jobs.bch
@@ -250,7 +251,7 @@ python3.10 -m pip install rpy2
 python3.10 -m pip install numpy
 python3.10 -m pip install pandas
 
-message0 "Downloading the action script..."
+message0 "Downloading the action script loader.py..."
 fetch_script loader.py annotation_pipeline
 submit_limit_jobs annotation_jobs.bch ../compressed_logs/annotation_job_id.txt
 waitTillCommandFinish

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -208,7 +208,7 @@ for dir in $(find . -mindepth 2 -maxdepth 2 -type d); do
   base_dir=$(basename "$dir")
   output_file="FileIndex_${base_dir}_$(printf "%.6f" $(echo $RANDOM/32767 | bc -l)).Ind"
   echo "sbatch --job-name=impc_stats_pipeline_job --mem=1G --time=2-00 \
--e ../../compressed_logs/minijobs_logs/ ${base_dir}.err -o ../../compressed_logs/minijobs_logs/${base_dir}.log \
+-e ../../compressed_logs/minijobs_logs/${base_dir}.err -o ../../compressed_logs/minijobs_logs/${base_dir}.log \
 --wrap=\"find $dir -type f -name '*.tsv' -exec realpath {} \; > $output_file\"" >> minijobs.bch
 done
 chmod 775 minijobs.bch

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -238,7 +238,7 @@ zip -q -rm allsingleindeces.zip *.Ind
 split -1000 AllResultsIndeces.txt split_index_
 
 message0 "Convert the mp_chooser JSON file to Rdata..."
-R --quiet -e "a = jsonlite::fromJSON('../../mp_chooser.json');save(a,file='../mp_chooser.json.Rdata')"
+R --quiet -e "a = jsonlite::fromJSON('../mp_chooser.json');save(a,file='../mp_chooser.json.Rdata')"
 export MP_CHOOSER_FILE=$(realpath ../mp_chooser.json.Rdata | tr -d '\n')
 
 if [[ -z "${MP_CHOOSER_FILE}" || ! -f "${MP_CHOOSER_FILE}" ]]; then

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -101,7 +101,7 @@ message0 "Step 1. Create jobs"
 step1_files=$(find ../input_parquet_files -type f -name '*.parquet' -exec realpath {} \;)
 for file in $step1_files; do
   file_name=$(basename "${file}" .parquet)
-  echo "sbatch --job-name=impc_stats_pipeline_job --mem=10G --time=00:10:00 -e ../compressed_logs/step2_logs/${file_name}.err -o ../compressed_logs/step2_logs${file_name}.log --wrap='Rscript Step2Parquet2Rdata.R $file'" >> jobs_step2_Parquet2Rdata.bch
+  echo "sbatch --job-name=impc_stats_pipeline_job --mem=10G --time=00:10:00 -e ../compressed_logs/step2_logs/${file_name}.err -o ../compressed_logs/step2_logs/${file_name}.log --wrap='Rscript Step2Parquet2Rdata.R $file'" >> jobs_step2_Parquet2Rdata.bch
 done
 
 message0 "Step 2. Read parquet files and create pseudo Rdata"

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -114,7 +114,8 @@ sbatch --job-name=zip_step2 --time=15:00:00 --mem=1G -o ../compressed_logs/zip_s
 message0 "Step 3. Merging pseudo Rdata files into single file for each procedure - jobs creator"
 dirs=$(find "${sp_results}/ProcedureScatterRdata" -maxdepth 1 -type d)
 for dir in $dirs; do
-  echo "sbatch --job-name=impc_stats_pipeline_job --mem=50G --time=01:30:00 -e ${dir}/step4_merge_rdatas.err -o ${dir}/step4_merge_rdatas.log --wrap='Rscript Step4MergingRdataFiles.R ${dir}'" >> jobs_step4_MergeRdatas.bch
+  file_name=$(basename "${dir}")
+  echo "sbatch --job-name=impc_stats_pipeline_job --mem=50G --time=01:30:00 -e ../compressed_logs/step4_logs/${file_name}_step4.err -o ../compressed_logs/step4_logs/${file_name}_step4.log --wrap='Rscript Step4MergingRdataFiles.R ${dir}'" >> jobs_step4_MergeRdatas.bch
 done
 
 message0 "Step 4. Merging pseudo Rdata files into single files per procedure"
@@ -122,8 +123,7 @@ fetch_script 0-ETL/Step4MergingRdataFiles.R
 sbatch --job-name=impc_stats_pipeline_job --time=01:00:00 --mem=1G -o ../compressed_logs/step4_job_id.txt --wrap="bash jobs_step4_MergeRdatas.bch"
 waitTillCommandFinish
 rm Step4MergingRdataFiles.R
-find . -type f -name '*.log' -exec zip -q -m ../compressed_logs/step4_logs.zip {} +
-find . -type f -name '*.err' -exec zip -q -m ../compressed_logs/step4_logs.zip {} +
+sbatch --job-name=zip_step2 --time=15:00:00 --mem=1G -o ../compressed_logs/zip_step4.txt --wrap="zip -r -m -q ../compressed_logs/step4_logs.zip ../compressed_logs/step4_logs/"
 
 message0 "Phase I. Compressing the log files and house cleaning..."
 zip -q -rm ../compressed_logs/phase1_jobs.zip *.bch

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -97,7 +97,7 @@ cd SP
 message0 "Phase I. Convert parquet files into Rdata..."
 
 message0 "Step 1. Create jobs"
-step1_files=$(find .. -type f -name '*.parquet' -exec realpath {} \;)
+step1_files=$(find ../input_parquet_files -type f -name '*.parquet' -exec realpath {} \;)
 for file in $step1_files; do
   echo "sbatch --job-name=impc_stats_pipeline_job --mem=10G --time=00:10:00 -e ${file}.err -o ${file}.log --wrap='Rscript Step2Parquet2Rdata.R $file'" >> jobs_step2_Parquet2Rdata.bch
 done
@@ -107,8 +107,8 @@ fetch_script 0-ETL/Step2Parquet2Rdata.R
 sbatch --job-name=impc_stats_pipeline_job --time=01:00:00 --mem=1G -o ../compressed_logs/step2_job_id.txt --wrap="bash jobs_step2_Parquet2Rdata.bch"
 waitTillCommandFinish
 rm Step2Parquet2Rdata.R
-find ../ -type f -name '*.log' -exec zip -q -m ../compressed_logs/step2_logs.zip {} +
-find ../ -type f -name '*.err' -exec zip -q -m ../compressed_logs/step2_logs.zip {} +
+find ../input_parquet_files -type f -name '*.log' -exec zip -q -m ../compressed_logs/step2_logs.zip {} +
+find ../input_parquet_files -type f -name '*.err' -exec zip -q -m ../compressed_logs/step2_logs.zip {} +
 
 message0 "Step 3. Merging pseudo Rdata files into single file for each procedure - jobs creator"
 dirs=$(find "${sp_results}/ProcedureScatterRdata" -maxdepth 1 -type d)

--- a/orchestration/orchestration.sh
+++ b/orchestration/orchestration.sh
@@ -208,15 +208,15 @@ for dir in $(find . -mindepth 2 -maxdepth 2 -type d); do
   base_dir=$(basename "$dir")
   output_file="FileIndex_${base_dir}_$(printf "%.6f" $(echo $RANDOM/32767 | bc -l)).Ind"
   echo "sbatch --job-name=impc_stats_pipeline_job --mem=1G --time=2-00 \
--e ${base_dir}_error.err -o ${base_dir}_output.log --wrap=\"find $dir -type f -name '*.tsv' -exec realpath {} \; > $output_file\"" >> minijobs.bch
+-e ../../compressed_logs/minijobs_logs/ ${base_dir}.err -o ../../compressed_logs/minijobs_logs/${base_dir}.log \
+--wrap=\"find $dir -type f -name '*.tsv' -exec realpath {} \; > $output_file\"" >> minijobs.bch
 done
 chmod 775 minijobs.bch
 submit_limit_jobs minijobs.bch ../../compressed_logs/minijobs_job_id.txt
 waitTillCommandFinish
 mv minijobs.bch ../../compressed_logs
+sbatch --job-name=compress_logs --time=15:00:00 --mem=1G -o ../compressed_logs/zip_minijobs.txt --wrap="zip -r -m -q ../../compressed_logs/minijobs_logs.zip ../../compressed_logs/minijobs_logs/"
 
-find . -type f -name '*_output.log' -exec zip -q -m ../../compressed_logs/minijobs_logs.zip {} +
-find . -type f -name '*_error.err' -exec zip -q -m ../../compressed_logs/minijobs_logs.zip {} +
 message0 "Moving single indeces into a separate directory called annotation_extractor..."
 mkdir ../../annotation_extractor
 chmod 775 ../../annotation_extractor
@@ -226,7 +226,7 @@ mv ../stats_results/Results_IMPC_SP_Windowed/*.Ind .
 message0 "Concatenating single index files to create a global index for the results..."
 cat *.Ind | shuf >> AllResultsIndeces.txt
 message0 "Zipping the single indeces..."
-zip -q -rm allsingleindeces.zip *.Ind
+sbatch --job-name=compress_logs --time=15:00:00 --mem=1G -o ../compressed_logs/zip_indeces.txt --wrap="zip -r -m -q allsingleindeces.zip *.Ind"
 split -1000 AllResultsIndeces.txt split_index_
 
 message0 "Convert the mp_chooser JSON file to Rdata..."


### PR DESCRIPTION
**Improvements**
- Closes #104
- Flatten directory structure of the statistical pipeline
- Job name is now DR specific
- Logs stored in one folder `compressed_logs`

**Optimisation**
- Logs compression changed from console command to sbatch job 
- Added deterministic shuf to make size of each statpacket evenly distributed
- Reduce number of statspackets by increasing records per file
- Closes #57 

**Performance Notes**
- Statistical pipeline execution time:
  - HDD: 3 days 12 hours
  - SSD: 3 days 5 hours (annotation pipeline failed due to timeout)
- SSD offers faster read/write operations but slower job submission.
- **Decision**: Continue using HDD for now.